### PR TITLE
Precise Video Cutting and Timestamp Correction

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,6 @@ fn main() {
 				let mut command = Command::new("ffmpeg");
 				command.arg("-hide_banner");
 				command.args(["-loglevel", if args.verbose { "info" } else { "warning" }]);
-				command.args(["-i", &clip.filename]);
 
 				if let Some(timecode) = &segment.start_timecode {
 					command.args(["-ss", &timecode]);
@@ -126,7 +125,10 @@ fn main() {
 					command.args(["-to", &timecode]);
 				}
 
+				command.arg("-accurate_seek");
+				command.args(["-i", &clip.filename]);
 				command.args(["-c", "copy"]);
+				command.args(["-avoid_negative_ts", "1"]);
 				command.arg(&temp_path);
 
 				let mut command_display =


### PR DESCRIPTION
used `-accurate_seek` to ensure precise cutting at the specified timestamp and `-avoid_negative_ts 1` to correct any negative timestamps, ensuring accurate timing in the output video.